### PR TITLE
v0.10.0

### DIFF
--- a/04_call_centre_renege.ipynb
+++ b/04_call_centre_renege.ipynb
@@ -1,0 +1,1111 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b6d8c5f-a44d-407f-9e4e-271b242cdcc1",
+   "metadata": {},
+   "source": [
+    "# Urgent care call centre with caller hang up (renege)\n",
+    "\n",
+    "In this notebook we will create a `ciw` network model from a specification in a JSON file.\n",
+    "\n",
+    "The model is a modification of the original call centre model to include caller waiting time patience. I.e. they hang up if the call is not answered quickly.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82f3dad9-2956-437c-8459-5451f8331de2",
+   "metadata": {},
+   "source": [
+    "## 1. Imports\n",
+    "\n",
+    "### 1.1 `json2ciw` imports\n",
+    "\n",
+    "**We will use:**\n",
+    "\n",
+    "*  `load_renege_call_model` function that loads the built in urgent care call centre JSON file.\n",
+    "*  `ProcessModel`: a `pydantic` schema that provides automatic validation of the JSON.\n",
+    "* `CiwConverter` that accepts a valid `ProcessModel` that represents a DES model and returns a `ciw` parameter `dict`.\n",
+    "* `multiple_replications`:runs the network model and results a `Dataframe` of replication results.\n",
+    "* `summarise_results`: provides a formatted table of mean results for each node in the network.\n",
+    "* `tidy_to_wide_format`: the results from `multiple_replications` are returned in tidy (stacked row) format. This function converts into wide format i.e. each column is a performance measure.\n",
+    "* `create_user_filtered_hist` generates a interactive plotly chart to view replications for each performance measure. It requires replication data in **wide** format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4fc9736a-c2b8-447f-b4fc-41ba058eb2d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from json2ciw.datasets import load_renege_call_model\n",
+    "from json2ciw.engine import (\n",
+    "    CiwConverter,\n",
+    "    multiple_replications\n",
+    ")\n",
+    "from json2ciw.results import (\n",
+    "    summarise_results, \n",
+    ")\n",
+    "\n",
+    "from json2ciw.schema import ProcessModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d810b325-6ceb-4004-9665-32dd08383c8a",
+   "metadata": {},
+   "source": [
+    "### 1.2 Other imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dd265a5a-dd08-44bb-ba1b-46542eb45be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ciw\n",
+    "from IPython.display import JSON\n",
+    "from rich import print"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7f5ad2f-a908-4fc7-accd-13d09789fc92",
+   "metadata": {},
+   "source": [
+    "## 2. Load JSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ae0f7993-e05a-4743-9fd2-9fc9c253b6d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_network = load_renege_call_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78948542-b159-4158-a0b8-630d38913a1e",
+   "metadata": {},
+   "source": [
+    "display as collapsible JSON.  Expand to view the details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "875ba1e9-6c93-436e-8902-00185cd90588",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "activities": [
+        {
+         "arrival_distribution": {
+          "parameters": {
+           "mean": 0.6
+          },
+          "type": "exponential"
+         },
+         "name": "Call Triage",
+         "renege_distribution": {
+          "parameters": {
+           "max": 10,
+           "min": 1
+          },
+          "type": "uniform"
+         },
+         "resource": {
+          "capacity": 13,
+          "name": "Operator"
+         },
+         "service_distribution": {
+          "parameters": {
+           "max": 10,
+           "min": 5,
+           "mode": 7
+          },
+          "type": "triangular"
+         },
+         "type": "activity"
+        },
+        {
+         "name": "Nurse Consultation",
+         "resource": {
+          "capacity": 9,
+          "name": "Nurse"
+         },
+         "service_distribution": {
+          "parameters": {
+           "max": 20,
+           "min": 10
+          },
+          "type": "uniform"
+         },
+         "type": "activity"
+        }
+       ],
+       "description": "Discrete Event Simulation of a Patient call handling process where calling hang up if call is not answered quickly.",
+       "name": "Call Handling Process with Renege.",
+       "transitions": [
+        {
+         "from": "Call Triage",
+         "probability": 0.4,
+         "to": "Nurse Consultation"
+        },
+        {
+         "from": "Call Triage",
+         "probability": 0.6,
+         "to": "Exit"
+        },
+        {
+         "from": "Nurse Consultation",
+         "probability": 1,
+         "to": "Exit"
+        }
+       ]
+      },
+      "text/plain": [
+       "<IPython.core.display.JSON object>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {
+      "application/json": {
+       "expanded": false,
+       "root": "root"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "JSON(json_network)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a746036-e63f-42cb-a08f-50294106e84b",
+   "metadata": {},
+   "source": [
+    "## 3. Convert to a ProcessModel\n",
+    "\n",
+    "A `ProcessModel` is a `pydantic` schema. It is independent of `ciw`. This early version will automatically validate that the JSON file is correct and that all transitions add up to 1.0 when it is created.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0adb2347-c767-47ea-9cf5-2ec015c7e631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_instance = ProcessModel(**json_network)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9ca1694-a97d-4993-a0bb-a2363b7a94f7",
+   "metadata": {},
+   "source": [
+    "The contents of the process model can be manually inspected by a developer as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4c7e50ee-04ee-4f9f-be79-ccecfdc83e0a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">ProcessModel</span><span style=\"font-weight: bold\">(</span>\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Call Handling Process with Renege.'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">description</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Discrete Event Simulation of a Patient call handling process where calling hang up if call is not </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">answered quickly.'</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">activities</span>=<span style=\"font-weight: bold\">[</span>\n",
+       "        <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Activity</span><span style=\"font-weight: bold\">(</span>\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Call Triage'</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'activity'</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">resource</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Resource</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Operator'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">capacity</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">13</span><span style=\"font-weight: bold\">)</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">service_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Distribution</span><span style=\"font-weight: bold\">(</span>\n",
+       "                <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'triangular'</span>,\n",
+       "                <span style=\"color: #808000; text-decoration-color: #808000\">parameters</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'min'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5.0</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'mode'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">7.0</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'max'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10.0</span><span style=\"font-weight: bold\">}</span>\n",
+       "            <span style=\"font-weight: bold\">)</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">arrival_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Distribution</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'exponential'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">parameters</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'mean'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.6</span><span style=\"font-weight: bold\">})</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">renege_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Distribution</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'uniform'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">parameters</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'min'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.0</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'max'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10.0</span><span style=\"font-weight: bold\">})</span>\n",
+       "        <span style=\"font-weight: bold\">)</span>,\n",
+       "        <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Activity</span><span style=\"font-weight: bold\">(</span>\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Nurse Consultation'</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'activity'</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">resource</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Resource</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">name</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Nurse'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">capacity</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">9</span><span style=\"font-weight: bold\">)</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">service_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Distribution</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'uniform'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">parameters</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'min'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">10.0</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'max'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">20.0</span><span style=\"font-weight: bold\">})</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">arrival_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">renege_distribution</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
+       "        <span style=\"font-weight: bold\">)</span>\n",
+       "    <span style=\"font-weight: bold\">]</span>,\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">transitions</span>=<span style=\"font-weight: bold\">[</span>\n",
+       "        <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Transition</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">source</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Call Triage'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">target</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Nurse Consultation'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">probability</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.4</span><span style=\"font-weight: bold\">)</span>,\n",
+       "        <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Transition</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">source</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Call Triage'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">target</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Exit'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">probability</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.6</span><span style=\"font-weight: bold\">)</span>,\n",
+       "        <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">Transition</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">source</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Nurse Consultation'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">target</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Exit'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">probability</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.0</span><span style=\"font-weight: bold\">)</span>\n",
+       "    <span style=\"font-weight: bold\">]</span>\n",
+       "<span style=\"font-weight: bold\">)</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1;35mProcessModel\u001b[0m\u001b[1m(\u001b[0m\n",
+       "    \u001b[33mname\u001b[0m=\u001b[32m'Call Handling Process with Renege.'\u001b[0m,\n",
+       "    \u001b[33mdescription\u001b[0m=\u001b[32m'Discrete Event Simulation of a Patient call handling process where calling hang up if call is not \u001b[0m\n",
+       "\u001b[32manswered quickly.'\u001b[0m,\n",
+       "    \u001b[33mactivities\u001b[0m=\u001b[1m[\u001b[0m\n",
+       "        \u001b[1;35mActivity\u001b[0m\u001b[1m(\u001b[0m\n",
+       "            \u001b[33mname\u001b[0m=\u001b[32m'Call Triage'\u001b[0m,\n",
+       "            \u001b[33mtype\u001b[0m=\u001b[32m'activity'\u001b[0m,\n",
+       "            \u001b[33mresource\u001b[0m=\u001b[1;35mResource\u001b[0m\u001b[1m(\u001b[0m\u001b[33mname\u001b[0m=\u001b[32m'Operator'\u001b[0m, \u001b[33mcapacity\u001b[0m=\u001b[1;36m13\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "            \u001b[33mservice_distribution\u001b[0m=\u001b[1;35mDistribution\u001b[0m\u001b[1m(\u001b[0m\n",
+       "                \u001b[33mtype\u001b[0m=\u001b[32m'triangular'\u001b[0m,\n",
+       "                \u001b[33mparameters\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'min'\u001b[0m: \u001b[1;36m5.0\u001b[0m, \u001b[32m'mode'\u001b[0m: \u001b[1;36m7.0\u001b[0m, \u001b[32m'max'\u001b[0m: \u001b[1;36m10.0\u001b[0m\u001b[1m}\u001b[0m\n",
+       "            \u001b[1m)\u001b[0m,\n",
+       "            \u001b[33marrival_distribution\u001b[0m=\u001b[1;35mDistribution\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'exponential'\u001b[0m, \u001b[33mparameters\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'mean'\u001b[0m: \u001b[1;36m0.6\u001b[0m\u001b[1m}\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "            \u001b[33mrenege_distribution\u001b[0m=\u001b[1;35mDistribution\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'uniform'\u001b[0m, \u001b[33mparameters\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'min'\u001b[0m: \u001b[1;36m1.0\u001b[0m, \u001b[32m'max'\u001b[0m: \u001b[1;36m10.0\u001b[0m\u001b[1m}\u001b[0m\u001b[1m)\u001b[0m\n",
+       "        \u001b[1m)\u001b[0m,\n",
+       "        \u001b[1;35mActivity\u001b[0m\u001b[1m(\u001b[0m\n",
+       "            \u001b[33mname\u001b[0m=\u001b[32m'Nurse Consultation'\u001b[0m,\n",
+       "            \u001b[33mtype\u001b[0m=\u001b[32m'activity'\u001b[0m,\n",
+       "            \u001b[33mresource\u001b[0m=\u001b[1;35mResource\u001b[0m\u001b[1m(\u001b[0m\u001b[33mname\u001b[0m=\u001b[32m'Nurse'\u001b[0m, \u001b[33mcapacity\u001b[0m=\u001b[1;36m9\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "            \u001b[33mservice_distribution\u001b[0m=\u001b[1;35mDistribution\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'uniform'\u001b[0m, \u001b[33mparameters\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'min'\u001b[0m: \u001b[1;36m10.0\u001b[0m, \u001b[32m'max'\u001b[0m: \u001b[1;36m20.0\u001b[0m\u001b[1m}\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "            \u001b[33marrival_distribution\u001b[0m=\u001b[3;35mNone\u001b[0m,\n",
+       "            \u001b[33mrenege_distribution\u001b[0m=\u001b[3;35mNone\u001b[0m\n",
+       "        \u001b[1m)\u001b[0m\n",
+       "    \u001b[1m]\u001b[0m,\n",
+       "    \u001b[33mtransitions\u001b[0m=\u001b[1m[\u001b[0m\n",
+       "        \u001b[1;35mTransition\u001b[0m\u001b[1m(\u001b[0m\u001b[33msource\u001b[0m=\u001b[32m'Call Triage'\u001b[0m, \u001b[33mtarget\u001b[0m=\u001b[32m'Nurse Consultation'\u001b[0m, \u001b[33mprobability\u001b[0m=\u001b[1;36m0\u001b[0m\u001b[1;36m.4\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "        \u001b[1;35mTransition\u001b[0m\u001b[1m(\u001b[0m\u001b[33msource\u001b[0m=\u001b[32m'Call Triage'\u001b[0m, \u001b[33mtarget\u001b[0m=\u001b[32m'Exit'\u001b[0m, \u001b[33mprobability\u001b[0m=\u001b[1;36m0\u001b[0m\u001b[1;36m.6\u001b[0m\u001b[1m)\u001b[0m,\n",
+       "        \u001b[1;35mTransition\u001b[0m\u001b[1m(\u001b[0m\u001b[33msource\u001b[0m=\u001b[32m'Nurse Consultation'\u001b[0m, \u001b[33mtarget\u001b[0m=\u001b[32m'Exit'\u001b[0m, \u001b[33mprobability\u001b[0m=\u001b[1;36m1\u001b[0m\u001b[1;36m.0\u001b[0m\u001b[1m)\u001b[0m\n",
+       "    \u001b[1m]\u001b[0m\n",
+       "\u001b[1m)\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(model_instance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "eedb1447-e6a2-4037-ad54-3c273933693c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```mermaid\n",
+       "graph TD\n",
+       "    %% Call Handling Process with Renege.: Discrete Event Simulation of a Patient call handling process where calling hang up if call is not answered quickly.\n",
+       "    Arrivals_Call_Triage(\"Time between arrivals<br/>Exponential(mean=0.6)\")\n",
+       "    Call_Triage[\"Call Triage<br/>Triangular(5.0, 7.0, 10.0)\"]\n",
+       "    Nurse_Consultation[\"Nurse Consultation<br/>Uniform(10.0, 20.0)\"]\n",
+       "    Renege_Call_Triage{{\"Renege<br/>Uniform(1.0, 10.0)\"}}\n",
+       "    Exit([\"Exit\"])\n",
+       "\n",
+       "    Arrivals_Call_Triage --> Call_Triage\n",
+       "    Call_Triage -.-> Renege_Call_Triage\n",
+       "    Call_Triage -->|40%| Nurse_Consultation\n",
+       "    Call_Triage -->|60%| Exit\n",
+       "    Nurse_Consultation --> Exit\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model_instance.display_diagram(include_resources=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b5b9cbde-c0f2-408d-886a-874c35b2d5da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```mermaid\n",
+       "graph TD\n",
+       "    %% Call Handling Process with Renege.: Discrete Event Simulation of a Patient call handling process where calling hang up if call is not answered quickly.\n",
+       "    Arrivals_Call_Triage(\"Time between arrivals<br/>Exponential(mean=0.6)\")\n",
+       "    Call_Triage[\"Call Triage<br/>Triangular(5.0, 7.0, 10.0)\"]\n",
+       "    Nurse_Consultation[\"Nurse Consultation<br/>Uniform(10.0, 20.0)\"]\n",
+       "    Renege_Call_Triage{{\"Renege<br/>Uniform(1.0, 10.0)\"}}\n",
+       "    Resource_Operator((\"Operator<br/>(13)\"))\n",
+       "    Resource_Nurse((\"Nurse<br/>(9)\"))\n",
+       "    Exit([\"Exit\"])\n",
+       "\n",
+       "    Arrivals_Call_Triage --> Call_Triage\n",
+       "    Resource_Operator -.Seize.-> Call_Triage\n",
+       "    Call_Triage -.Release.-> Resource_Operator\n",
+       "    Resource_Nurse -.Seize.-> Nurse_Consultation\n",
+       "    Nurse_Consultation -.Release.-> Resource_Nurse\n",
+       "    Call_Triage -.-> Renege_Call_Triage\n",
+       "    Call_Triage -->|40%| Nurse_Consultation\n",
+       "    Call_Triage -->|60%| Exit\n",
+       "    Nurse_Consultation --> Exit\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model_instance.display_diagram(include_resources=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "66e589db-47ec-480c-957d-97c9c8d2c063",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Activity</th>\n",
+       "      <th>Phase</th>\n",
+       "      <th>Distribution Type</th>\n",
+       "      <th>Parameters</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Arrival</td>\n",
+       "      <td>Exponential</td>\n",
+       "      <td>mean=0.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Service</td>\n",
+       "      <td>Triangular</td>\n",
+       "      <td>min=5.0, mode=7.0, max=10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Renege</td>\n",
+       "      <td>Uniform</td>\n",
+       "      <td>min=1.0, max=10.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Nurse Consultation</td>\n",
+       "      <td>Service</td>\n",
+       "      <td>Uniform</td>\n",
+       "      <td>min=10.0, max=20.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             Activity    Phase Distribution Type                   Parameters\n",
+       "0         Call Triage  Arrival       Exponential                     mean=0.6\n",
+       "1         Call Triage  Service        Triangular  min=5.0, mode=7.0, max=10.0\n",
+       "2         Call Triage   Renege           Uniform            min=1.0, max=10.0\n",
+       "3  Nurse Consultation  Service           Uniform           min=10.0, max=20.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# summary of distributions\n",
+    "model_instance.get_distributions_df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a06718ab-f00e-4638-a506-67fec64c6b83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Call Triage</th>\n",
+       "      <th>Nurse Consultation</th>\n",
+       "      <th>Exit</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Source Activity</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Call Triage</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Nurse Consultation</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    Call Triage  Nurse Consultation  Exit\n",
+       "Source Activity                                          \n",
+       "Call Triage                 0.0                 0.4   0.6\n",
+       "Nurse Consultation          0.0                 0.0   1.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# summary of routing percentages\n",
+    "model_instance.get_routing_matrix_df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "92cdb466-f6df-4618-92a5-646ce62df753",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Resource</th>\n",
+       "      <th>Activity</th>\n",
+       "      <th>Count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Operator</td>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Nurse</td>\n",
+       "      <td>Nurse Consultation</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Resource            Activity  Count\n",
+       "0  Operator         Call Triage     13\n",
+       "1     Nurse  Nurse Consultation      9"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# resources\n",
+    "model_instance.get_resources_df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66c72042-f45b-40ea-bc3b-c0460a00f62a",
+   "metadata": {},
+   "source": [
+    "## 3. Convert to a `ciw` Network Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "586b7cef-387b-4e22-bacc-20b7ad04187e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adapter = CiwConverter(model_instance)\n",
+    "network_params = adapter.generate_params()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc75093-5baf-48b9-8f0c-4e86d4ee6194",
+   "metadata": {},
+   "source": [
+    "The variable `network_params` is a python `dict` that contains all the parameters that `ciw` requires for a very simple queuing model. This can be passed as keyword args to the `ciw.create_network` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8258fbad-3ddc-4638-9b40-f6311fae9064",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'number_of_servers': [13, 9],\n",
+       " 'arrival_distributions': [Exponential(rate=1.6666666666666667), None],\n",
+       " 'service_distributions': [Triangular(lower=5.0, mode=7.0, upper=10.0),\n",
+       "  Uniform(lower=10.0, upper=20.0)],\n",
+       " 'reneging_time_distributions': [Uniform(lower=1.0, upper=10.0), None],\n",
+       " 'routing': [[0.0, 0.4], [0.0, 0.0]]}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "network_params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c53f328a-f951-4890-975b-1f0558df321a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">class</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #008000; text-decoration-color: #008000\">'ciw.network.Network'</span><span style=\"font-weight: bold\">&gt;</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'ciw.network.Network'\u001b[0m\u001b[1m>\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# we use ciw's native `create_network` method\n",
+    "network = ciw.create_network(**network_params)\n",
+    "print(type(network))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3d484439-eb59-4640-b017-30aa62fcc7b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Quick simulation run worked!\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Quick simulation run worked!\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Run a quick simulation to verify it works without crashing...\n",
+    "sim = ciw.Simulation(network)\n",
+    "sim.simulate_until_max_time(50)\n",
+    "print(\"Quick simulation run worked!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4677d85-9a83-4c8e-a1c5-838af73512b1",
+   "metadata": {},
+   "source": [
+    "## 4. Run the model for multiple replications\n",
+    "\n",
+    "The `multiple_replications` function returns a `DataFrame` that contains one row per activity per replication.  So if there are two nodes there are two rows for each replication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "b8f5f123-d68d-45f8-ac55-ce1d01b823ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rep</th>\n",
+       "      <th>node_id</th>\n",
+       "      <th>activity_name</th>\n",
+       "      <th>resource_name</th>\n",
+       "      <th>resource_capacity</th>\n",
+       "      <th>n_service</th>\n",
+       "      <th>mean_wait</th>\n",
+       "      <th>mean_service</th>\n",
+       "      <th>utilisation</th>\n",
+       "      <th>mean_Lq</th>\n",
+       "      <th>n_renege</th>\n",
+       "      <th>mean_wait_renege</th>\n",
+       "      <th>mean_wait_all</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Operator</td>\n",
+       "      <td>13</td>\n",
+       "      <td>2251</td>\n",
+       "      <td>0.703426</td>\n",
+       "      <td>7.360011</td>\n",
+       "      <td>90.784999</td>\n",
+       "      <td>1.243545</td>\n",
+       "      <td>117.0</td>\n",
+       "      <td>1.771724</td>\n",
+       "      <td>0.756210</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Nurse Consultation</td>\n",
+       "      <td>Nurse</td>\n",
+       "      <td>9</td>\n",
+       "      <td>797</td>\n",
+       "      <td>168.985355</td>\n",
+       "      <td>15.028666</td>\n",
+       "      <td>98.944327</td>\n",
+       "      <td>93.528700</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Operator</td>\n",
+       "      <td>13</td>\n",
+       "      <td>2245</td>\n",
+       "      <td>0.825940</td>\n",
+       "      <td>7.342525</td>\n",
+       "      <td>88.484260</td>\n",
+       "      <td>1.467736</td>\n",
+       "      <td>135.0</td>\n",
+       "      <td>1.920765</td>\n",
+       "      <td>0.888042</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Nurse Consultation</td>\n",
+       "      <td>Nurse</td>\n",
+       "      <td>9</td>\n",
+       "      <td>828</td>\n",
+       "      <td>70.782173</td>\n",
+       "      <td>15.035560</td>\n",
+       "      <td>98.179626</td>\n",
+       "      <td>40.699750</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Call Triage</td>\n",
+       "      <td>Operator</td>\n",
+       "      <td>13</td>\n",
+       "      <td>2241</td>\n",
+       "      <td>0.572294</td>\n",
+       "      <td>7.305171</td>\n",
+       "      <td>89.163630</td>\n",
+       "      <td>0.967762</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>1.791386</td>\n",
+       "      <td>0.605114</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   rep  node_id       activity_name resource_name  resource_capacity  \\\n",
+       "0    0        1         Call Triage      Operator                 13   \n",
+       "1    0        2  Nurse Consultation         Nurse                  9   \n",
+       "2    1        1         Call Triage      Operator                 13   \n",
+       "3    1        2  Nurse Consultation         Nurse                  9   \n",
+       "4    2        1         Call Triage      Operator                 13   \n",
+       "\n",
+       "   n_service   mean_wait  mean_service  utilisation    mean_Lq  n_renege  \\\n",
+       "0       2251    0.703426      7.360011    90.784999   1.243545     117.0   \n",
+       "1        797  168.985355     15.028666    98.944327  93.528700       NaN   \n",
+       "2       2245    0.825940      7.342525    88.484260   1.467736     135.0   \n",
+       "3        828   70.782173     15.035560    98.179626  40.699750       NaN   \n",
+       "4       2241    0.572294      7.305171    89.163630   0.967762      62.0   \n",
+       "\n",
+       "   mean_wait_renege  mean_wait_all  \n",
+       "0          1.771724       0.756210  \n",
+       "1               NaN            NaN  \n",
+       "2          1.920765       0.888042  \n",
+       "3               NaN            NaN  \n",
+       "4          1.791386       0.605114  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Run replications with activity/resource names\n",
+    "df_reps = multiple_replications(\n",
+    "    network, \n",
+    "    model_instance, \n",
+    "    num_reps=100, \n",
+    "    runtime=2880,\n",
+    "    warmup=1440,\n",
+    "    n_jobs=-1 # parallel reps\n",
+    ")\n",
+    "\n",
+    "df_reps.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "827dec4a-702d-4083-9c20-ea791e0b4c69",
+   "metadata": {},
+   "source": [
+    "Filter the nodes with the usual `pandas` syntax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ab8987d4-9b70-4f8a-8aef-e7547516687c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>rep</th>\n",
+       "      <th>node_id</th>\n",
+       "      <th>activity_name</th>\n",
+       "      <th>resource_name</th>\n",
+       "      <th>resource_capacity</th>\n",
+       "      <th>n_service</th>\n",
+       "      <th>mean_wait</th>\n",
+       "      <th>mean_service</th>\n",
+       "      <th>utilisation</th>\n",
+       "      <th>mean_Lq</th>\n",
+       "      <th>n_renege</th>\n",
+       "      <th>mean_wait_renege</th>\n",
+       "      <th>mean_wait_all</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [rep, node_id, activity_name, resource_name, resource_capacity, n_service, mean_wait, mean_service, utilisation, mean_Lq, n_renege, mean_wait_renege, mean_wait_all]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_reps.loc[df_reps['activity_name'] == \"Service 1\"].head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e261229-48fc-432e-b0c5-919655a4bc64",
+   "metadata": {},
+   "source": [
+    "## 5. Summarise results\n",
+    "\n",
+    "If needed there is a built in function to create a `DataFrame` that contains a mean summary of all metrics across the nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "eb8e2d99-8973-4c30-b79b-634593644519",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>activity</th>\n",
+       "      <th>Metric</th>\n",
+       "      <th>Call Triage (Operator)</th>\n",
+       "      <th>Nurse Consultation (Nurse)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Mean completed services</td>\n",
+       "      <td>2269.5</td>\n",
+       "      <td>800.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Mean waiting time</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>126.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Mean service time</td>\n",
+       "      <td>7.3</td>\n",
+       "      <td>15.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Mean utilisation</td>\n",
+       "      <td>89.4</td>\n",
+       "      <td>99.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Mean queue length</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>69.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Mean reneges</td>\n",
+       "      <td>122.6</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Mean reneging wait</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Mean wait (all completed)</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "activity                     Metric  Call Triage (Operator)  \\\n",
+       "0           Mean completed services                  2269.5   \n",
+       "1                 Mean waiting time                     0.8   \n",
+       "2                 Mean service time                     7.3   \n",
+       "3                  Mean utilisation                    89.4   \n",
+       "4                 Mean queue length                     1.4   \n",
+       "5                      Mean reneges                   122.6   \n",
+       "6                Mean reneging wait                     2.0   \n",
+       "7         Mean wait (all completed)                     0.9   \n",
+       "\n",
+       "activity  Nurse Consultation (Nurse)  \n",
+       "0                              800.7  \n",
+       "1                              126.1  \n",
+       "2                               15.0  \n",
+       "3                               99.1  \n",
+       "4                               69.4  \n",
+       "5                                NaN  \n",
+       "6                                NaN  \n",
+       "7                                NaN  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get summary table\n",
+    "summary = summarise_results(df_reps)\n",
+    "summary.round(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ Consistent identifier (represents all versions, resolves to latest):
 ### Changed
 
 * `ProcessModel.to_mermaid()` refactored.  Refactored distribution formatting to function. Added Renege as hexagon with dashed arrow.
+* `ProcessModel.get_distributions_df()` now handles renege distributions
+* `engine.CiwConverter` now handles renege distributions as part of `generate_params`
 
 ### Added
 
 * `schema.Activity` now has a optional `renege_distribution` field.
+* Two new examples in `datasets`:  `load_mm1_renege_model` and `load_renege_call_model`
+* `04_call_centre_renege.ipynb` example notebook added.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Consistent identifier (represents all versions, resolves to latest):
 * `ProcessModel.to_mermaid()` refactored.  Refactored distribution formatting to function. Added Renege as hexagon with dashed arrow.
 * `ProcessModel.get_distributions_df()` now handles renege distributions
 * `engine.CiwConverter` now handles renege distributions as part of `generate_params`
+* `ui` modified to handle renege distributions.
+* `example_app.py` new models demonstrating renege have been added.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Consistent identifier (represents all versions, resolves to latest): 
 
+## 0.10.0
+
+### Changed
+
+* `ProcessModel.to_mermaid()` refactored.  Refactored distribution formatting to function. Added Renege as hexagon with dashed arrow.
+
+### Added
+
+* `schema.Activity` now has a optional `renege_distribution` field.
+
 ## 0.9.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you reuse any of the code, or the tutorial helps you work, please provide a c
   month        = apr,
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {v0.9.0},
+  version      = {v0.10.0},
   doi          = {10.5281/zenodo.18879547},
   url          = {https://doi.org/10.5281/zenodo.18879547},
 }

--- a/example_app.py
+++ b/example_app.py
@@ -3,7 +3,8 @@ from json2ciw.datasets import (
     load_jackson_network_model, 
     load_three_node_network_model,
     load_six_node_ucc_model,
-    load_renge_call_model,
+    load_renege_call_model,
+    load_mm1_renege_model,
     
 )
 from json2ciw.engine import CiwConverter
@@ -22,6 +23,7 @@ model_loaders = {
     "Three Node Network": load_three_node_network_model,
     "Urgent Care Treatment Centre": load_six_node_ucc_model,
     "Renge Call Centre": load_renge_call_model,
+    "M/M/1 with Renege": load_mm1_renege_model,
 }
 
 # Create a dropdown to select the model

--- a/example_app.py
+++ b/example_app.py
@@ -22,7 +22,7 @@ model_loaders = {
     "Call Centre": load_call_centre_model,
     "Three Node Network": load_three_node_network_model,
     "Urgent Care Treatment Centre": load_six_node_ucc_model,
-    "Renge Call Centre": load_renge_call_model,
+    "Renge Call Centre": load_renege_call_model,
     "M/M/1 with Renege": load_mm1_renege_model,
 }
 

--- a/example_app.py
+++ b/example_app.py
@@ -3,6 +3,8 @@ from json2ciw.datasets import (
     load_jackson_network_model, 
     load_three_node_network_model,
     load_six_node_ucc_model,
+    load_renge_call_model,
+    
 )
 from json2ciw.engine import CiwConverter
 from json2ciw import render_simulation_app
@@ -19,6 +21,7 @@ model_loaders = {
     "Call Centre": load_call_centre_model,
     "Three Node Network": load_three_node_network_model,
     "Urgent Care Treatment Centre": load_six_node_ucc_model,
+    "Renge Call Centre": load_renge_call_model,
 }
 
 # Create a dropdown to select the model

--- a/json2ciw/__init__.py
+++ b/json2ciw/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Tom Monks"
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 from .datasets import load_call_centre_model, load_model_file
 from .engine import CiwConverter, multiple_replications

--- a/json2ciw/__init__.py
+++ b/json2ciw/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Tom Monks"
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 from .datasets import load_call_centre_model, load_model_file
 from .engine import CiwConverter, multiple_replications

--- a/json2ciw/__init__.py
+++ b/json2ciw/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Tom Monks"
-__version__ = "0.10.1"
+__version__ = "0.10.0"
 
 from .datasets import load_call_centre_model, load_model_file
 from .engine import CiwConverter, multiple_replications

--- a/json2ciw/datasets.py
+++ b/json2ciw/datasets.py
@@ -19,6 +19,10 @@ THREE_NODE_PATH = Path(__file__).parent.joinpath("models", THREE_NODE_FILE_NAME)
 SIX_NODE_UCC_FILE_NAME = "six_node_ucc.json"
 SIX_NODE_UCC_PATH = Path(__file__).parent.joinpath("models", SIX_NODE_UCC_FILE_NAME)
 
+# Call centre example with reneging calls
+RENGE_FILE_NAME = "call_renege.json"
+RENGE_PATH = Path(__file__).parent.joinpath("models", RENGE_FILE_NAME)
+
 def load_model_file(file_path: str) -> Dict[str, Any]:
     """
     Load a JSON specification for a call centre model from a file.
@@ -139,3 +143,26 @@ def load_six_node_ucc_model() -> Dict[str, Any]:
         If there are permissions issues or other I/O errors opening the file.
     """
     return load_model_file(SIX_NODE_UCC_PATH)
+
+def load_renge_call_model() -> Dict[str, Any]:
+    """
+    Load a JSON specification for a Urgent care call
+    centre with calls that renege if they wait for too long
+    
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary containing the parsed JSON data. The keys are strings
+        representing configuration fields (e.g., "process", "activities") 
+        and values are the corresponding model parameters.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file specified by `file_path` cannot be found.
+    json.JSONDecodeError
+        If the file content is not valid JSON.
+    OSError
+        If there are permissions issues or other I/O errors opening the file.
+    """
+    return load_model_file(RENGE_PATH)

--- a/json2ciw/datasets.py
+++ b/json2ciw/datasets.py
@@ -20,12 +20,12 @@ SIX_NODE_UCC_FILE_NAME = "six_node_ucc.json"
 SIX_NODE_UCC_PATH = Path(__file__).parent.joinpath("models", SIX_NODE_UCC_FILE_NAME)
 
 # Call centre example with reneging calls
-RENGE_FILE_NAME = "call_renege.json"
-RENGE_PATH = Path(__file__).parent.joinpath("models", RENGE_FILE_NAME)
+RENEGE_FILE_NAME = "call_renege.json"
+RENEGE_PATH = Path(__file__).parent.joinpath("models", RENEGE_FILE_NAME)
 
 # m/m/1 with renege
-MM1_RENGE_FILE_NAME = "mm1_renege.json"
-MM1_RENGE_PATH = Path(__file__).parent.joinpath("models", MM1_RENGE_FILE_NAME)
+MM1_RENEGE_FILE_NAME = "mm1_renege.json"
+MM1_RENEGE_PATH = Path(__file__).parent.joinpath("models", MM1_RENEGE_FILE_NAME)
 
 
 def load_model_file(file_path: str) -> Dict[str, Any]:
@@ -170,7 +170,7 @@ def load_renege_call_model() -> Dict[str, Any]:
     OSError
         If there are permissions issues or other I/O errors opening the file.
     """
-    return load_model_file(RENGE_PATH)
+    return load_model_file(RENEGE_PATH)
 
 def load_mm1_renege_model() -> Dict[str, Any]:
     """
@@ -193,5 +193,5 @@ def load_mm1_renege_model() -> Dict[str, Any]:
     OSError
         If there are permissions issues or other I/O errors opening the file.
     """
-    return load_model_file(MM1_RENGE_PATH)
+    return load_model_file(MM1_RENEGE_PATH)
 

--- a/json2ciw/datasets.py
+++ b/json2ciw/datasets.py
@@ -149,7 +149,7 @@ def load_six_node_ucc_model() -> Dict[str, Any]:
     """
     return load_model_file(SIX_NODE_UCC_PATH)
 
-def load_renge_call_model() -> Dict[str, Any]:
+def load_renege_call_model() -> Dict[str, Any]:
     """
     Load a JSON specification for a Urgent care call
     centre with calls that renege if they wait for too long
@@ -172,7 +172,7 @@ def load_renge_call_model() -> Dict[str, Any]:
     """
     return load_model_file(RENGE_PATH)
 
-def load_mm1_renge_model() -> Dict[str, Any]:
+def load_mm1_renege_model() -> Dict[str, Any]:
     """
     Load a JSON specification for a M/M/1 with
     customers that renege if they wait for too long

--- a/json2ciw/datasets.py
+++ b/json2ciw/datasets.py
@@ -23,6 +23,11 @@ SIX_NODE_UCC_PATH = Path(__file__).parent.joinpath("models", SIX_NODE_UCC_FILE_N
 RENGE_FILE_NAME = "call_renege.json"
 RENGE_PATH = Path(__file__).parent.joinpath("models", RENGE_FILE_NAME)
 
+# m/m/1 with renege
+MM1_RENGE_FILE_NAME = "mm1_renege.json"
+MM1_RENGE_PATH = Path(__file__).parent.joinpath("models", MM1_RENGE_FILE_NAME)
+
+
 def load_model_file(file_path: str) -> Dict[str, Any]:
     """
     Load a JSON specification for a call centre model from a file.
@@ -166,3 +171,27 @@ def load_renge_call_model() -> Dict[str, Any]:
         If there are permissions issues or other I/O errors opening the file.
     """
     return load_model_file(RENGE_PATH)
+
+def load_mm1_renge_model() -> Dict[str, Any]:
+    """
+    Load a JSON specification for a M/M/1 with
+    customers that renege if they wait for too long
+
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary containing the parsed JSON data. The keys are strings
+        representing configuration fields (e.g., "process", "activities")
+        and values are the corresponding model parameters.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file specified by `file_path` cannot be found.
+    json.JSONDecodeError
+        If the file content is not valid JSON.
+    OSError
+        If there are permissions issues or other I/O errors opening the file.
+    """
+    return load_model_file(MM1_RENGE_PATH)
+

--- a/json2ciw/engine.py
+++ b/json2ciw/engine.py
@@ -213,6 +213,8 @@ def multiple_replications(
             "activity_name": activity.name,
             "resource_name": activity.resource.name,
             "resource_capacity": activity.resource.capacity,
+            # added in v0.10.0
+            "has_reneging": activity.renege_distribution is not None,
         }
 
     # Run independent replications in parallel, one per seed
@@ -231,7 +233,6 @@ def multiple_replications(
     records = [row for rep_rows in results for row in rep_rows]
 
     return pd.DataFrame.from_records(records)
-
 
 def _single_run(
     network: ciw.Network,
@@ -253,100 +254,138 @@ def _single_run(
     ----------
     network : ciw.Network
         Configured Ciw network defining the queueing system structure,
-        service and arrival processes, and routing.
+        arrival processes, service processes, routing, and optional reneging
+        behaviour.
     node_metadata : dict[int, dict]
-        Mapping from Ciw node identifiers (1-indexed) to metadata dictionaries
-        containing activity and resource information. Expected keys include
-        ``"activity_name"``, ``"resource_name"``, and ``"resource_capacity"``.
+        Mapping from Ciw node identifiers (1-indexed) to metadata
+        dictionaries containing activity and resource information. Expected
+        keys include ``"activity_name"``, ``"resource_name"``,
+        ``"resource_capacity"``, and optionally ``"has_reneging"``.
     rep : int, optional
         Replication index used both as an identifier in the output and as the
         random seed for the simulation. Default is 0.
     warmup : float, optional
         Length of the warmup period to exclude from statistics. Records with
-        arrival times strictly less than this value are filtered out to reduce
-        initialization bias. Default is 0.0.
+        arrival times strictly less than this value are filtered out.
+        Default is 0.0.
     runtime : float, optional
         Simulation time horizon for this replication. Units must match those
-        used in the arrival and service time distributions. Default is 1000.0.
+        used in the arrival, service, and reneging time distributions.
+        Default is 1000.0.
 
     Returns
     -------
     list[dict]
-        List of row dictionaries, one per transitive node, containing:
-        
-        - ``"rep"`` : int
-          Replication index.
-        - ``"node_id"`` : int
-          Ciw node identifier (1-indexed).
-        - ``"activity_name"`` : str
-          Human-readable activity name for this node.
-        - ``"resource_name"`` : str
-          Name of the resource associated with this node.
-        - ``"resource_capacity"`` : int
-          Number of servers at this node.
-        - ``"arrivals"`` : int
-          Number of completed visits to this node.
-        - ``"mean_wait"`` : float
-          Mean waiting time before service for completed customers.
-        - ``"mean_service"`` : float
-          Mean service time for completed customers.
-        - ``"utilisation"`` : float
-          Time-averaged server utilisation at this node, as a percentage.
-        - ``"mean_Lq"`` : float
-          Time-averaged mean number of customers in queue over the effective
-          horizon ``runtime - warmup``.
+        List of row dictionaries, one per transitive node.
+
+        Core fields returned for all nodes:
+        - ``rep`` : int
+            Replication index.
+        - ``node_id`` : int
+            Ciw node identifier (1-indexed).
+        - ``activity_name`` : str
+            Human-readable activity name for this node.
+        - ``resource_name`` : str
+            Name of the resource associated with this node.
+        - ``resource_capacity`` : int
+            Number of servers at this node.
+        - ``n_service`` : int
+            Number of completed service records at this node.
+        - ``mean_wait`` : float
+            Mean waiting time among customers who started service at this
+            node.
+        - ``mean_service`` : float
+            Mean service time among completed service records at this node.
+        - ``utilisation`` : float
+            Time-averaged server utilisation at this node, as a percentage.
+        - ``mean_Lq`` : float
+            Estimated mean number of customers in queue over the effective
+            horizon ``runtime - warmup``.
+
+        Additional fields for nodes with reneging enabled:
+        - ``n_renege`` : int
+            Number of completed reneging records at this node.
+        - ``mean_wait_renege`` : float
+            Mean waiting time among customers who reneged at this node.
+        - ``mean_wait_all`` : float
+            Mean waiting time across both served and reneging customers at
+            this node.
 
     Notes
     -----
     The Ciw random number generators are seeded via ``ciw.seed(rep)`` to
     ensure reproducibility of each replication. Warmup filtering is applied
-    using the arrival times of customer records, consistent with Ciw usage
-    examples.[web:39][web:48]
+    using the arrival times of customer records. This potentially needs modifying
+    at some point.
+
+    Since version 0.10.0 will return reneging stats if a node has a reneging distribution.
     """
     ciw.seed(rep)
     Q = ciw.Simulation(network)
     Q.simulate_until_max_time(runtime)
-    
-    recs = Q.get_all_records()
-    
-    # Optional warmup filter. 
-    # Ciw examples uses arrival times of entities
+
+    # modified v0.10.0 - separate service and reneged
+    recs = Q.get_all_records(only=["service", "renege"])
+
+    # Warmup filter
     if warmup > 0:
         recs = [r for r in recs if r.arrival_date >= warmup]
-        
+
     rows = []
-    # Loop over transitive nodes (service centres)
+    horizon = runtime - warmup
+
     for node in Q.transitive_nodes:
         node_id = node.id_number
         meta = node_metadata.get(node_id, {})
 
+        # split records - modified v0.10.0
         node_recs = [r for r in recs if r.node == node_id]
-        waits = [r.waiting_time for r in node_recs]
-        services = [r.service_time for r in node_recs]
+        service_recs = [r for r in node_recs if r.record_type == "service"]
+        renege_recs = [r for r in node_recs if r.record_type == "renege"]
 
-        arrivals = len(node_recs)
-        mean_wait = statistics.mean(waits) if waits else 0.0
-        mean_service = statistics.mean(services) if services else 0.0
+        # separate and total waiting times v0.10.0
+        service_waits = [r.waiting_time for r in service_recs]
+        renege_waits = [r.waiting_time for r in renege_recs]
+        all_waits = [r.waiting_time for r in node_recs]
 
-        # Ciw server_utilisation gives time-averaged busy fraction
+        service_times = [r.service_time for r in service_recs]
+
+        n_service = len(service_recs)
+        n_renege = len(renege_recs)
+
+        mean_wait_service = statistics.mean(service_waits) if service_waits else 0.0
+        mean_wait_renege = statistics.mean(renege_waits) if renege_waits else 0.0
+        mean_wait_all = statistics.mean(all_waits) if all_waits else 0.0
+        mean_service = statistics.mean(service_times) if service_times else 0.0
+
         util = node.server_utilisation
 
-        # Time-weighted mean number in queue (Lq)
-        horizon = runtime - warmup
-        total_wait = sum(waits)
-        mean_Lq = total_wait / horizon if horizon > 0 else 0.0
+        total_wait_all = sum(all_waits)
+        mean_Lq = total_wait_all / horizon if horizon > 0 else 0.0
 
-        rows.append({
+        # default row - modified v0.10.0
+        row = {
             "rep": rep,
             "node_id": node_id,
             "activity_name": meta.get("activity_name", f"Node {node_id}"),
             "resource_name": meta.get("resource_name", "Unknown"),
             "resource_capacity": meta.get("resource_capacity", 0),
-            "arrivals": arrivals,
-            "mean_wait": mean_wait,
+            "n_service": n_service,
+            "mean_wait": mean_wait_service,
             "mean_service": mean_service,
             "utilisation": util * 100,
             "mean_Lq": mean_Lq,
+        }
+
+        # if add in renege wait if needed.
+        if meta.get("has_reneging", False):
+            row.update({
+                "n_renege": n_renege,
+                "mean_wait_renege": mean_wait_renege,
+                "mean_wait_all": mean_wait_all,
             })
-        
+
+
+        rows.append(row)
+
     return rows

--- a/json2ciw/engine.py
+++ b/json2ciw/engine.py
@@ -27,6 +27,7 @@ class CiwConverter:
         number_of_servers = []
         service_distributions = []
         arrival_distributions = []
+        reneging_time_distributions = []
 
         # 3. Iterate through Activities to build Node properties
         for act in self.model.activities:
@@ -43,6 +44,13 @@ class CiwConverter:
                 # If no arrival distribution is specified in JSON, it means no external arrivals
                 # None = old NoArrivals pre ciw v3
                 arrival_distributions.append(None)
+
+            # -- Renege Distribution (Optional) --
+            # TM Added v0.10.0
+            if act.renege_distribution:
+                reneging_time_distributions.append(self._make_ciw_dist(act.renege_distribution))
+            else:
+                reneging_time_distributions.append(None)
 
         # 4. Build Routing Matrix (Process Flow -> Probability Matrix)
         # Initialize an N x N matrix with 0.0
@@ -65,6 +73,7 @@ class CiwConverter:
             "number_of_servers": number_of_servers,
             "arrival_distributions": arrival_distributions,
             "service_distributions": service_distributions,
+            "reneging_time_distributions": reneging_time_distributions,
             "routing": routing
         }
     
@@ -195,18 +204,6 @@ def multiple_replications(
             Time-averaged server utilisation (fraction busy)
         - mean_Lq : float
             Time-averaged mean number of customers in queue
-
-    Examples
-    --------
-    >>> process_model = ProcessModel.model_validate(json_data)
-    >>> network = build_ciw_network(process_model)
-    >>> df_raw = run_replications_general(
-    ...     network, 
-    ...     process_model, 
-    ...     num_reps=100, 
-    ...     runtime=1000
-    ... )
-    >>> summary = summarise_results(df_raw)
     """
     # Build a mapping from node_id (1-indexed) to activity/resource info
     node_metadata = {}

--- a/json2ciw/models/call_renege.json
+++ b/json2ciw/models/call_renege.json
@@ -1,6 +1,6 @@
 {
-    "name": "Call Handling Process",
-    "description": "Discrete Event Simulation of a Patient call handling process.",
+    "name": "Call Handling Process with Renege.",
+    "description": "Discrete Event Simulation of a Patient call handling process where calling hang up if call is not answered quickly.",
     "activities": [
       {
         "name": "Call Triage",

--- a/json2ciw/models/call_renege.json
+++ b/json2ciw/models/call_renege.json
@@ -1,0 +1,37 @@
+{
+    "name": "Call Handling Process",
+    "description": "Discrete Event Simulation of a Patient call handling process.",
+    "activities": [
+      {
+        "name": "Call Triage",
+        "type": "activity",
+        "resource": { "name": "Operator", "capacity": 13 },
+        "service_distribution": {
+          "type": "triangular",
+          "parameters": { "min": 5, "mode": 7, "max": 10 }
+        },
+        "arrival_distribution": {
+          "type": "exponential",
+          "parameters": { "mean": 0.6 }
+        },
+        "renege_distribution": {
+          "type": "uniform",
+          "parameters": { "min": 1.0, "max": 10.0 }
+        }
+      },
+      {
+        "name": "Nurse Consultation",
+        "type": "activity",
+        "resource": { "name": "Nurse", "capacity": 9 },
+        "service_distribution": {
+          "type": "uniform",
+          "parameters": { "min": 10, "max": 20 }
+        }
+      }
+    ],
+    "transitions": [
+      { "from": "Call Triage", "to": "Nurse Consultation", "probability": 0.4 },
+      { "from": "Call Triage", "to": "Exit", "probability": 0.6 },
+      { "from": "Nurse Consultation", "to": "Exit", "probability": 1.0 }
+    ]
+}

--- a/json2ciw/models/mm1_renege.json
+++ b/json2ciw/models/mm1_renege.json
@@ -1,0 +1,26 @@
+{
+    "name": "M/M/1 with renege",
+    "description": "A simple M/M/1 queuing system with reneging customers.",
+    "activities": [
+      {
+        "name": "Service",
+        "type": "activity",
+        "resource": { "name": "Resource1", "capacity": 1 },
+        "service_distribution": {
+          "type": "Exponential",
+          "parameters": { "rate": 1.5 }
+        },
+        "arrival_distribution": {
+          "type": "exponential",
+          "parameters": { "rate": 1.0 }
+        },
+        "renege_distribution": {
+          "type": "exponential",
+          "parameters": { "rate": 0.5 }
+        }
+      },
+    ],
+    "transitions": [
+      { "from": "Service", "to": "Exit", "probability": 1.0 },
+    ]
+}

--- a/json2ciw/models/mm1_renege.json
+++ b/json2ciw/models/mm1_renege.json
@@ -7,7 +7,7 @@
         "type": "activity",
         "resource": { "name": "Resource1", "capacity": 1 },
         "service_distribution": {
-          "type": "Exponential",
+          "type": "exponential",
           "parameters": { "rate": 1.5 }
         },
         "arrival_distribution": {
@@ -18,9 +18,9 @@
           "type": "exponential",
           "parameters": { "rate": 0.5 }
         }
-      },
+      }
     ],
     "transitions": [
-      { "from": "Service", "to": "Exit", "probability": 1.0 },
+      { "from": "Service", "to": "Exit", "probability": 1.0 }
     ]
 }

--- a/json2ciw/results.py
+++ b/json2ciw/results.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import plotly.graph_objects as go
 
+
 def summarise_results(
     df_reps: pd.DataFrame,
     metric_name_map: dict[str, str] | None = None,
@@ -9,57 +10,71 @@ def summarise_results(
     """
     Aggregate replication results and transpose so metrics are rows
     and activity names are columns.
-    
+
     Parameters
     ----------
     df_reps : pd.DataFrame
-        Raw tidy format replication results from multiple_replications()
+        Raw tidy-format replication results from multiple_replications().
     metric_name_map : dict or None, optional
         Dictionary mapping internal metric names to friendly names.
-        If None, uses default friendly names. Pass False or {} to keep original names.
+        If None, default friendly names are used. Pass {} to keep original names.
     include_resource_in_colname : bool, default True
         If True, column headers include both activity and resource name.
     """
-    
-    # Default friendly metric names
     DEFAULT_METRICS = {
-        "mean_arrivals": "Mean arrivals",
+        "mean_n_service": "Mean completed services",
         "mean_wait": "Mean waiting time",
         "mean_service": "Mean service time",
         "mean_utilisation": "Mean utilisation",
         "mean_Lq": "Mean queue length",
+        "mean_n_renege": "Mean reneges",
+        "mean_renege_rate": "Mean reneging rate",
+        "mean_wait_renege": "Mean reneging wait",
+        "mean_wait_all": "Mean wait (all completed)",
     }
-    
-    # Use default if None, otherwise use provided dict (even if empty)
+
     if metric_name_map is None:
         metric_name_map = DEFAULT_METRICS
-    
+
+    agg_spec = {
+        "mean_n_service": ("n_service", "mean"),
+        "mean_wait": ("mean_wait", "mean"),
+        "mean_service": ("mean_service", "mean"),
+        "mean_utilisation": ("utilisation", "mean"),
+        "mean_Lq": ("mean_Lq", "mean"),
+    }
+
+    optional_metrics = {
+        "mean_n_renege": ("n_renege", "mean"),
+        "mean_renege_rate": ("renege_rate", "mean"),
+        "mean_wait_renege": ("mean_wait_renege", "mean"),
+        "mean_wait_all": ("mean_wait_all", "mean"),
+    }
+
+    for out_name, spec in optional_metrics.items():
+        source_col = spec[0]
+        if source_col in df_reps.columns:
+            agg_spec[out_name] = spec
+
     summary = (
         df_reps.groupby(["activity_name", "resource_name"])
-        .agg(
-            mean_arrivals=("arrivals", "mean"),
-            mean_wait=("mean_wait", "mean"),
-            mean_service=("mean_service", "mean"),
-            mean_utilisation=("utilisation", "mean"),
-            mean_Lq=("mean_Lq", "mean"),
-        )
+        .agg(**agg_spec)
         .reset_index()
     )
 
     if include_resource_in_colname:
-        summary["activity"] = summary["activity_name"] + " (" + summary["resource_name"] + ")"
+        summary["activity"] = (
+            summary["activity_name"] + " (" + summary["resource_name"] + ")"
+        )
     else:
         summary["activity"] = summary["activity_name"]
 
-    summary = summary[
-        ["activity", "mean_arrivals", "mean_wait", "mean_service", "mean_utilisation", "mean_Lq"]
-    ]
+    metric_cols = ["activity"] + list(agg_spec.keys())
+    summary = summary[metric_cols]
 
-    # Transpose: metrics as rows, activities as columns
     summary = summary.set_index("activity").T
     summary.index.name = "Metric"
 
-    # Apply metric name mapping
     if metric_name_map:
         summary = summary.rename(index=metric_name_map)
 
@@ -68,111 +83,112 @@ def summarise_results(
 
 def tidy_to_wide_format(
     df_reps: pd.DataFrame,
+    include_resource_in_colname: bool = False,
 ) -> pd.DataFrame:
     """
     Return replication results in wide format:
     one row per replication, one column per (metric, activity[/resource]).
-    
+
     Parameters
     ----------
     df_reps : pd.DataFrame
-        Tidy replication results from multiple_replications(), with
-        columns like: rep, activity_name, resource_name,
-        arrivals, mean_wait, mean_service, utilisation, mean_Lq.
+        Tidy replication results from multiple_replications().
+    include_resource_in_colname : bool, default False
+        If True, wide-format columns include resource names as well.
     """
-   
-    df_reps = df_reps.assign(activity=df_reps["activity_name"])
+    if include_resource_in_colname:
+        activity = df_reps["activity_name"] + " (" + df_reps["resource_name"] + ")"
+    else:
+        activity = df_reps["activity_name"]
 
-    # Subset metrics you care about
-    metric_cols = ["arrivals", "mean_wait", "mean_service", "utilisation", "mean_Lq"]
+    df_reps = df_reps.assign(activity=activity)
+
+    metric_cols = [
+        "n_service",
+        "mean_wait",
+        "mean_service",
+        "utilisation",
+        "mean_Lq",
+    ]
+
+    optional_cols = [
+        "n_renege",
+        "renege_rate",
+        "mean_wait_renege",
+        "mean_wait_all",
+    ]
+    metric_cols.extend([c for c in optional_cols if c in df_reps.columns])
+
     df_metrics = df_reps[["rep", "activity"] + metric_cols]
 
-    # Pivot to wide: (activity, metric) -> columns
     wide = (
         df_metrics
         .set_index(["rep", "activity"])
         .unstack("activity")
     )
 
-    # Flatten MultiIndex columns to strings like "Mean wait [Call triage (Operators)]"
     wide.columns = [f"{metric} [{activity}]" for metric, activity in wide.columns]
 
-    # Bring rep back as single index
-    wide = wide.reset_index()
-    wide = wide.set_index("rep")
+    wide = wide.reset_index().set_index("rep")
 
     return wide
 
 
-def create_user_filtered_hist(results):
-    '''
-    Create a plotly histogram that includes a drop down list that allows a user
-    to select which KPI is displayed as a histogram
-    
-    Params:
+def create_user_filtered_hist(results: pd.DataFrame) -> go.Figure:
+    """
+    Create a Plotly histogram with a dropdown that lets the user
+    choose which metric to display.
+
+    Parameters
+    ----------
+    results : pd.DataFrame
+        Wide-format results with one row per replication and one
+        column per KPI.
+
+    Returns
     -------
-    results: pd.Dataframe
-        rows = replications, cols = KPIs
-        
-    Returns:
-    -------
-    plotly.figure
-    
-    Sources:
-    ------
-    The code in this function was parly adapted from two sources:
-    1. https://stackoverflow.com/questions/59406167/plotly-how-to-filter-a-pandas-dataframe-using-a-dropdown-menu
-    
-    Thanks and credit to `vestland` the author of the reponse.
-    
-    2. https://plotly.com/python/dropdowns/
-    '''
-    # create a figure
+    plotly.graph_objects.Figure
+        Interactive histogram figure.
+    """
     fig = go.Figure()
 
-    # set up a trace
-    fig.add_trace(go.Histogram(x=results[results.columns[0]]))
+    first_col = results.columns[0]
+    fig.add_trace(go.Histogram(x=results[first_col].dropna()))
 
     buttons = []
-
-    # create list of drop down items - KPIs
-    # the params in the code would need to vary depending on the type of chart.
-    # The histogram will show the first KPI by default
     for col in results.columns:
-        buttons.append(dict(method='restyle',
-                            label=col,
-                            visible=True,
-                            args=[{'x':[results[col]],
-                                   'type':'histogram'}, [0]],
-                            )
-                      )
+        buttons.append(
+            dict(
+                method="restyle",
+                label=col,
+                args=[{"x": [results[col].dropna()], "type": "histogram"}, [0]],
+            )
+        )
 
-
-    # create update menu and parameters
-    updatemenu = []
-    your_menu = dict()
-    updatemenu.append(your_menu)
-
-    updatemenu[0]['buttons'] = buttons
-    updatemenu[0]['direction'] = 'down'
-    updatemenu[0]['showactive'] = True
-    updatemenu[0]['x'] = 0.25
-    updatemenu[0]['y'] = 1.1
-    updatemenu[0]['xanchor'] = 'right'
-    updatemenu[0]['yanchor'] = 'bottom'
-    #updatemenu[0]['pad'] = {"r": 10, "t": 10}
-    
-    
-    
-    # add dropdown menus to the figure
-    fig.update_layout(showlegend=False, 
-                      updatemenus=updatemenu)
-    
-    
-    # add label for selecting performance measure
     fig.update_layout(
-    annotations=[
-        dict(text="Performance measure", x=0, xref="paper", y=1.25, 
-             yref="paper", align="left", showarrow=False)
-    ])
+        showlegend=False,
+        updatemenus=[
+            dict(
+                buttons=buttons,
+                direction="down",
+                showactive=True,
+                x=0.25,
+                y=1.1,
+                xanchor="right",
+                yanchor="bottom",
+            )
+        ],
+        annotations=[
+            dict(
+                text="Performance measure",
+                x=0,
+                xref="paper",
+                y=1.25,
+                yref="paper",
+                align="left",
+                showarrow=False,
+            )
+        ],
+    )
+
     return fig

--- a/json2ciw/schema.py
+++ b/json2ciw/schema.py
@@ -30,6 +30,7 @@ class Activity(BaseModel):
     resource: Resource
     service_distribution: Distribution
     arrival_distribution: Optional[Distribution] = None
+    renege_distribution: Optional[Distribution] = None
 
 
 class Transition(BaseModel):

--- a/json2ciw/schema.py
+++ b/json2ciw/schema.py
@@ -221,6 +221,17 @@ class ProcessModel(BaseModel):
                 "Distribution Type": srv.type.capitalize(),
                 "Parameters": ", ".join(f"{k}={v}" for k, v in srv.parameters.items())
             })
+
+            # added v0.10.0 to show renege parameters if present.
+            if activity.renege_distribution:
+                ren = activity.renege_distribution
+                records.append({
+                    "Activity": activity.name,
+                    "Phase": "Renege",
+                    "Distribution Type": ren.type.capitalize(),
+                    "Parameters": ", ".join(f"{k}={v}" for k, v in ren.parameters.items())
+                })
+
             
         return pd.DataFrame(records)
 

--- a/json2ciw/schema.py
+++ b/json2ciw/schema.py
@@ -30,6 +30,7 @@ class Activity(BaseModel):
     resource: Resource
     service_distribution: Distribution
     arrival_distribution: Optional[Distribution] = None
+    # added v0.10.0
     renege_distribution: Optional[Distribution] = None
 
 
@@ -88,7 +89,8 @@ class ProcessModel(BaseModel):
     def _format_dist(self, dist: Distribution, context: str = "service") -> str:
         """Format a distribution for Mermaid labels.
         
-        Args:
+        Parameters:
+        -----------
             context: 'arrival' (verbose prefix), 'service'/'renege' (compact).
         """
         p = dist.parameters
@@ -213,6 +215,7 @@ class ProcessModel(BaseModel):
             f.write(mermaid_code)
 
     def get_distributions_df(self) -> pd.DataFrame:
+        """Get all distributions in the model as a DataFrame"""
         records = []
         for activity in self.activities:
             if activity.arrival_distribution:
@@ -246,6 +249,7 @@ class ProcessModel(BaseModel):
         return pd.DataFrame(records)
 
     def get_routing_matrix_df(self) -> pd.DataFrame:
+        """ Get the routing probabilities as a DataFrame"""
         activities = [a.name for a in self.activities]
         targets = activities + ["Exit"]
         matrix = pd.DataFrame(0.0, index=activities, columns=targets)
@@ -258,6 +262,7 @@ class ProcessModel(BaseModel):
         return matrix
     
     def get_resources_df(self) -> pd.DataFrame:
+        """ Get the activity resources as a DataFrame"""
         records = []
         for activity in self.activities:
             records.append({

--- a/json2ciw/schema.py
+++ b/json2ciw/schema.py
@@ -85,6 +85,39 @@ class ProcessModel(BaseModel):
 
         return self
     
+    def _format_dist(self, dist: Distribution, context: str = "service") -> str:
+        """Format a distribution for Mermaid labels.
+        
+        Args:
+            context: 'arrival' (verbose prefix), 'service'/'renege' (compact).
+        """
+        p = dist.parameters
+        
+        # Parameter formatting (shared logic)
+        if dist.type == "exponential" and "rate" in p:
+            params = f"Exponential(λ={p['rate']:.1f})"
+        elif dist.type == "exponential" and "mean" in p:
+            params = f"Exponential(mean={p['mean']:.1f})"
+        elif dist.type == "triangular":
+            params = f"Triangular({p.get('min', 0)}, {p.get('mode', 0)}, {p.get('max', 0)})"
+        elif dist.type == "uniform":
+            params = f"Uniform({p.get('min', 0)}, {p.get('max', 0)})"
+        elif dist.type == "deterministic" and "value" in p:
+            params = f"Deterministic({p['value']})"
+        elif dist.type == "lognormal":
+            params = f"Lognormal(mean={p.get('mean', 0)}, stdev={p.get('stdev', 0)})"
+        elif dist.type == "gamma":
+            params = f"Gamma(shape={p.get('shape', 0)}, scale={p.get('scale', 0)})"
+        elif dist.type == "normal":
+            params = f"Normal(mean={p.get('mean', 0)}, sd={p.get('sd', 0)})"
+        else:
+            params = dist.type
+        
+        # Context-specific prefix
+        if context == "arrival":
+            return f"Time between arrivals<br/>{params}"
+        return params
+
     def to_mermaid(self, include_resources: bool = True) -> str:
         """Convert the process model to Mermaid flowchart syntax."""
         lines = ["```mermaid", "graph TD"]
@@ -97,62 +130,29 @@ class ProcessModel(BaseModel):
         
         entry_activities = [a for a in self.activities if a.arrival_distribution]
         
+        # --- Arrival nodes ---
         for activity in entry_activities:
             node_id = make_node_id(activity.name)
             arrival_id = f"Arrivals_{node_id}"
-            
-            arr_dist = activity.arrival_distribution
-            p = arr_dist.parameters
-            
-            if arr_dist.type == "exponential" and "rate" in p:
-                arr_label = f"Time between arrivals<br/>Exponential(λ={p['rate']:.1f})"
-            elif arr_dist.type == "exponential" and "mean" in p:
-                arr_label = f"Time between arrivals<br/>Exponential(mean={p['mean']:.1f})"
-            elif arr_dist.type == "triangular":
-                arr_label = f"Time between arrivals<br/>Triangular({p.get('min', 0)}, {p.get('mode', 0)}, {p.get('max', 0)})"
-            elif arr_dist.type == "uniform":
-                arr_label = f"Time between arrivals<br/>Uniform({p.get('min', 0)}, {p.get('max', 0)})"
-            elif arr_dist.type == "deterministic" and "value" in p:
-                arr_label = f"Time between arrivals<br/>Deterministic({p['value']})"
-            # ADDED: lognormal and gamma formatting
-            elif arr_dist.type == "lognormal":
-                arr_label = f"Time between arrivals<br/>Lognormal(mean={p.get('mean', 0)}, stdev={p.get('stdev', 0)})"
-            elif arr_dist.type == "gamma":
-                arr_label = f"Time between arrivals<br/>Gamma(shape={p.get('shape', 0)}, scale={p.get('scale', 0)})"
-            else:
-                arr_label = f"Time between arrivals<br/>{arr_dist.type}"
-            
+            arr_label = self._format_dist(activity.arrival_distribution, context="arrival")
             lines.append(f'    {arrival_id}("{arr_label}")')
         
+        # --- Activity nodes ---
         for activity in self.activities:
             node_id = make_node_id(activity.name)
-            
-            serv_dist = activity.service_distribution
-            p = serv_dist.parameters
-            
-            if serv_dist.type == "exponential" and "rate" in p:
-                dist_info = f"Exp(λ={p['rate']:.1f})"
-            elif serv_dist.type == "exponential" and "mean" in p:
-                dist_info = f"Exp(mean={p['mean']:.1f})"
-            elif serv_dist.type == "triangular":
-                dist_info = f"Tri({p.get('min', 0)}, {p.get('mode', 0)}, {p.get('max', 0)})"
-            elif serv_dist.type == "uniform":
-                dist_info = f"Uniform({p.get('min', 0)}, {p.get('max', 0)})"
-            elif serv_dist.type == "deterministic" and "value" in p:
-                dist_info = f"Det({p['value']})"
-            # ADDED: lognormal and gamma formatting
-            elif serv_dist.type == "lognormal":
-                dist_info = f"Lognormal(mean={p.get('mean', 0)}, stdev={p.get('stdev', 0)})"
-            elif serv_dist.type == "gamma":
-                dist_info = f"Gamma(shape={p.get('shape', 0)}, scale={p.get('scale', 0)})"
-            elif serv_dist.type == "normal":
-                dist_info = f"Normal(mean={p.get('mean', 0)}, sd={p.get('sd', 0)})"
-            else:
-                dist_info = serv_dist.type
-            
+            dist_info = self._format_dist(activity.service_distribution)
             label = f"{activity.name}<br/>{dist_info}"
             lines.append(f'    {node_id}["{label}"]')
         
+        # --- Renege nodes (parallel renege flow) ---
+        for activity in self.activities:
+            if activity.renege_distribution:
+                node_id = make_node_id(activity.name)
+                renege_id = f"Renege_{node_id}"
+                renege_info = self._format_dist(activity.renege_distribution)
+                lines.append('    ' + renege_id + '{{"Renege<br/>' + renege_info + '"}}')
+        
+        # --- Resource nodes ---
         if include_resources:
             seen_resources = set()
             for activity in self.activities:
@@ -165,11 +165,13 @@ class ProcessModel(BaseModel):
         lines.append('    Exit(["Exit"])')
         lines.append("")
         
+        # --- Edges: arrivals ---
         for activity in entry_activities:
             node_id = make_node_id(activity.name)
             arrival_id = f"Arrivals_{node_id}"
             lines.append(f'    {arrival_id} --> {node_id}')
         
+        # --- Edges: resource seize/release ---
         if include_resources:
             for activity in self.activities:
                 node_id = make_node_id(activity.name)
@@ -177,6 +179,14 @@ class ProcessModel(BaseModel):
                 lines.append(f'    {resource_id} -.Seize.-> {node_id}')
                 lines.append(f'    {node_id} -.Release.-> {resource_id}')
         
+        # --- Edges: renege (dashed optional path) ---
+        for activity in self.activities:
+            if activity.renege_distribution:
+                node_id = make_node_id(activity.name)
+                renege_id = f"Renege_{node_id}"
+                lines.append(f'    {node_id} -.-> {renege_id}')
+        
+        # --- Edges: transitions ---
         for transition in self.transitions:
             source_id = make_node_id(transition.source)
             target_id = make_node_id(transition.target) if transition.target != "Exit" else "Exit"

--- a/json2ciw/schema.py
+++ b/json2ciw/schema.py
@@ -87,11 +87,34 @@ class ProcessModel(BaseModel):
         return self
     
     def _format_dist(self, dist: Distribution, context: str = "service") -> str:
-        """Format a distribution for Mermaid labels.
-        
-        Parameters:
-        -----------
-            context: 'arrival' (verbose prefix), 'service'/'renege' (compact).
+        """
+        Format a distribution as a human-readable string for Mermaid labels.
+
+        Parameters
+        ----------
+        dist : Distribution
+            The distribution object to format, containing a ``type`` and
+            ``parameters`` dictionary.
+        context : str, optional
+            Rendering context. Use ``'arrival'`` to prepend
+            ``'Time between arrivals<br/>'`` for arrival node labels.
+            Use ``'service'`` or ``'renege'`` for compact activity and
+            renege node labels. Default is ``'service'``.
+
+        Returns
+        -------
+        str
+            A formatted string representation of the distribution suitable
+            for embedding in a Mermaid node label. For example:
+            ``'Exponential(λ=0.5)'`` or
+            ``'Time between arrivals<br/>Exponential(λ=0.5)'``.
+
+        Notes
+        -----
+        Supported distribution types are: ``'exponential'``, ``'triangular'``,
+        ``'uniform'``, ``'deterministic'``, ``'lognormal'``, ``'gamma'``, and
+        ``'normal'``. Unrecognised types fall back to returning the raw type
+        string.
         """
         p = dist.parameters
         
@@ -121,7 +144,51 @@ class ProcessModel(BaseModel):
         return params
 
     def to_mermaid(self, include_resources: bool = True) -> str:
-        """Convert the process model to Mermaid flowchart syntax."""
+        """
+        Convert the process model to a Mermaid flowchart string.
+
+        Generates a ``graph TD`` Mermaid diagram representing the queuing
+        network, including arrival sources, activity nodes, optional resource
+        nodes, renege side-flows, and routing transitions.
+
+        Parameters
+        ----------
+        include_resources : bool, optional
+            If ``True``, resource nodes are rendered as stadium shapes with
+            dashed ``Seize`` and ``Release`` edges connecting them to their
+            associated activities. Default is ``True``.
+
+        Returns
+        -------
+        str
+            A string containing a fenced Mermaid code block (including
+            opening and closing triple-backtick markers) ready for rendering
+            in a Jupyter notebook or Markdown document.
+
+        Notes
+        -----
+        Node types used in the diagram:
+
+        - **Rounded rectangle** ``( )``: Arrival source nodes, labelled with
+        the inter-arrival distribution.
+        - **Rectangle** ``[ ]``: Activity nodes, labelled with the activity
+        name and service distribution.
+        - **Hexagon** ``{{ }}``: Renege nodes, connected to their parent
+        activity via a dashed edge. Rendered only when an activity has a
+        ``renege_distribution`` defined.
+        - **Stadium** ``([ ])``: The terminal ``Exit`` node.
+        - **Double circle** ``(( ))``: Resource nodes, rendered when
+        ``include_resources=True``.
+
+        Transition edges with probability < 1.0 are labelled with the
+        percentage. Renege edges are always dashed (``-.->``). Resource
+        seize/release edges are dashed with text labels.
+
+        Examples
+        --------
+        >>> print(model.to_mermaid())
+        >>> model.to_mermaid(include_resources=False)
+        """
         lines = ["```mermaid", "graph TD"]
         
         if self.description:

--- a/json2ciw/ui.py
+++ b/json2ciw/ui.py
@@ -87,6 +87,7 @@ def render_simulation_app(default_params, model_metadata, valid_process_model=No
         'number_of_servers': [],
         'arrival_distributions': [],
         'service_distributions': [],
+        'reneging_time_distributions': [],
         'routing': []
     }
     
@@ -118,10 +119,16 @@ def render_simulation_app(default_params, model_metadata, valid_process_model=No
         if srv_dist_data is not None:
             st.sidebar.markdown(f"**Service Distribution**")
         srv_dist = _render_distribution_ui(srv_dist_data, node_name, "Service")
-        
-        # need to account for distributions like the lognormal requiring conversion
         updated_params['service_distributions'].append(srv_dist)
         
+        # Reneging Distribution (Conditional Header)
+        # TM added v0.10.0
+        renege_dist_data = default_params['reneging_time_distributions'][i]
+        if renege_dist_data is not None:
+            st.sidebar.markdown(f"**Renege Distribution**")
+        renege_dist = _render_distribution_ui(renege_dist_data, node_name, "Renege")
+        updated_params['reneging_time_distributions'].append(renege_dist)
+
         st.sidebar.divider()
 
     # --- UI: MAIN PANEL TABS ---


### PR DESCRIPTION
Added renege functionality

### Changed

* `ProcessModel.to_mermaid()` refactored.  Refactored distribution formatting to function. Added Renege as hexagon with dashed arrow.
* `ProcessModel.get_distributions_df()` now handles renege distributions
* `engine.CiwConverter` now handles renege distributions as part of `generate_params`
* `ui` modified to handle renege distributions.
* `example_app.py` new models demonstrating renege have been added.

### Added

* `schema.Activity` now has a optional `renege_distribution` field.
* Two new examples in `datasets`:  `load_mm1_renege_model` and `load_renege_call_model`
* `04_call_centre_renege.ipynb` example notebook added.